### PR TITLE
add truck count needed for an order

### DIFF
--- a/ShipIt/Models/ApiModels/OutboundResponse.cs
+++ b/ShipIt/Models/ApiModels/OutboundResponse.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace ShipIt.Models.ApiModels
+{
+    public class OutboundResponse : Response
+    {
+        public int CountOfTrucks { get; set; }
+       
+        public OutboundResponse() { }
+        
+        public OutboundResponse(int countOfTrucks) {
+            CountOfTrucks = countOfTrucks;
+            Success = true;
+        }
+    }
+}


### PR DESCRIPTION
- we've got the app and tests running
- rebuilt the database using the database dump 
- added to OutBoundOrder endpoint to count (roughly) how many trucks are needed for an order